### PR TITLE
Remove hideKeyboard function

### DIFF
--- a/iOS-SwiftUI-Firebase-Login-Template/Utils/Extensions.swift
+++ b/iOS-SwiftUI-Firebase-Login-Template/Utils/Extensions.swift
@@ -78,11 +78,3 @@ extension String {
         return result
     }
 }
-
-public extension View {
-    #if canImport(UIKit)
-    func hideKeyboard() {
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-    }
-    #endif
-}

--- a/iOS-SwiftUI-Firebase-Login-Template/Views/Login.swift
+++ b/iOS-SwiftUI-Firebase-Login-Template/Views/Login.swift
@@ -150,9 +150,6 @@ struct Login: View {
 		} message: {
 			Text("Check your email for a link to reset your password.")
 		}
-		.onTapGesture {
-			hideKeyboard()
-		}
 	}
 	
 	// Helper methods


### PR DESCRIPTION
Addresses #3 

`hideKeyboard()` was a helper function that I used before I updated the implementation a couple weeks ago. It's no longer needed now that the text fields in Login are `@FocusState`